### PR TITLE
Added an alternative way of defining a RibbonCommand using annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ $ gradle runApp
 ```bash
 $ @Path(value = "/forlayos", method = HttpMethod.GET )
 $ @Path(value = "/call_to_ms2", method = HttpMethod.GET )
+$ @Path(value = "/call_to_ms2_alt", method = HttpMethod.GET )
 ```
 
 

--- a/src/main/java/com/scmspain/workshop/command/CampaignRibbonCommandAlt.java
+++ b/src/main/java/com/scmspain/workshop/command/CampaignRibbonCommandAlt.java
@@ -1,0 +1,11 @@
+package com.scmspain.workshop.command;
+
+import com.netflix.ribbon.RibbonRequest;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Created by xavier.fornes on 28/08/15.
+ */
+public interface CampaignRibbonCommandAlt {
+    public RibbonRequest<ByteBuf> getForlayo2(String id);
+}

--- a/src/main/java/com/scmspain/workshop/command/CampaignRibbonCommandAltImpl.java
+++ b/src/main/java/com/scmspain/workshop/command/CampaignRibbonCommandAltImpl.java
@@ -1,0 +1,23 @@
+package com.scmspain.workshop.command;
+
+import com.netflix.ribbon.RibbonRequest;
+import com.netflix.ribbon.proxy.annotation.ClientProperties;
+import com.netflix.ribbon.proxy.annotation.ClientProperties.Property;
+import com.netflix.ribbon.proxy.annotation.Http;
+import com.netflix.ribbon.proxy.annotation.Var;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Created by xavier.fornes on 28/08/15.
+ */
+@ClientProperties(
+        properties = {
+                @Property(name = "DeploymentContextBasedVipAddresses", value = "microservice-2"),
+                @Property(name = "NIWSServerListClassName", value = "com.netflix.niws.loadbalancer.DiscoveryEnabledNIWSServerList"),
+        }
+)
+public interface CampaignRibbonCommandAltImpl extends CampaignRibbonCommandAlt {
+    @Override
+    @Http(method = Http.HttpMethod.GET, uri="/forlayo2/{id}")
+    public RibbonRequest<ByteBuf> getForlayo2(@Var("id") String id);
+}

--- a/src/main/java/com/scmspain/workshop/controller/ForlayoEndpoint.java
+++ b/src/main/java/com/scmspain/workshop/controller/ForlayoEndpoint.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.netflix.ribbon.RibbonRequest;
 import com.scmspain.workshop.command.CampaignRibbonCommand;
+import com.scmspain.workshop.command.CampaignRibbonCommandAlt;
 import io.netty.buffer.ByteBuf;
 import io.reactivex.netty.protocol.http.server.HttpServerRequest;
 import io.reactivex.netty.protocol.http.server.HttpServerResponse;
@@ -18,42 +19,42 @@ import java.nio.charset.Charset;
 @Endpoint
 public class ForlayoEndpoint {
 
-
     private CampaignRibbonCommand campaignRibbonCommand;
+    private CampaignRibbonCommandAlt campaignRibbonCommandAlt;
 
     @Inject
-    public ForlayoEndpoint(CampaignRibbonCommand campaignRibbonCommand)
+    public ForlayoEndpoint(CampaignRibbonCommand campaignRibbonCommand, CampaignRibbonCommandAlt campaignRibbonCommandAlt)
     {
         this.campaignRibbonCommand = campaignRibbonCommand;
+        this.campaignRibbonCommandAlt = campaignRibbonCommandAlt;
     }
-
 
     @Path(value = "/forlayos", method = HttpMethod.GET )
     public Observable<Void> getForlayosResource(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
 
-
             return response.writeStringAndFlush("Minglanillas!" + "\n")
                     .concatWith(response.close());
-
-
-
     }
 
     @Path(value = "/call_to_ms2", method = HttpMethod.GET )
     public Observable<Void> getMicroservice2Resource(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
-
-
         RibbonRequest<ByteBuf> ribbonResponse = campaignRibbonCommand.getForlayo2("1");
+
         return ribbonResponse.observe()
                 .flatMap(data -> {
                             return response.writeStringAndFlush(data.toString(Charset.defaultCharset())).concatWith(response.close());
                         }
                 );
-
-
-
     }
 
+    @Path(value = "/call_to_ms2_alt", method = HttpMethod.GET )
+    public Observable<Void> getMicroservice2AltResource(HttpServerRequest<ByteBuf> request, HttpServerResponse<ByteBuf> response) {
+        RibbonRequest<ByteBuf> ribbonRequest = campaignRibbonCommandAlt.getForlayo2("23");
 
-
+        return ribbonRequest.observe()
+                .flatMap(data -> {
+                            return response.writeStringAndFlush(data.toString(Charset.defaultCharset())).concatWith(response.close());
+                        }
+                );
+    }
 }

--- a/src/main/java/com/scmspain/workshop/core/AppServer.java
+++ b/src/main/java/com/scmspain/workshop/core/AppServer.java
@@ -6,6 +6,9 @@ import com.netflix.client.config.DefaultClientConfigImpl;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.governator.annotations.Modules;
+import com.netflix.ribbon.Ribbon;
+import com.scmspain.workshop.command.CampaignRibbonCommandAlt;
+import com.scmspain.workshop.command.CampaignRibbonCommandAltImpl;
 import com.scmspain.workshop.controller.ForlayoEndpoint;
 import com.scmspain.workshop.core.health.HealthCheck;
 import com.scmspain.workshop.security.AuthenticationManager;
@@ -46,6 +49,7 @@ public interface AppServer {
             bind(AuthenticationManagerInterface.class).to(AuthenticationManager.class);
             bind(ForlayoEndpoint.class).asEagerSingleton();
             bind(IClientConfig.class).to(DefaultClientConfigImpl.class);
+            bind(CampaignRibbonCommandAlt.class).toInstance(Ribbon.from(CampaignRibbonCommandAltImpl.class));
 
             super.configure();
         }


### PR DESCRIPTION
CampaignRibbonCommandAlt as the application service (interface)
and CampaignRibbonCommandAltImpl  as the implementation of that app service using Ribbon
